### PR TITLE
Removed redundant parameters from test policy 

### DIFF
--- a/tests/policy/root.yml
+++ b/tests/policy/root.yml
@@ -4,6 +4,12 @@
   annotations:
     description: Policy for Ansible master and remote hosts
   body:
+
+  - !host
+    id: ansible-master
+    annotations:
+      description: Host for running Ansible on remote targets
+
   - !layer &remote_hosts_layer
     id: remote_hosts
     annotations:
@@ -15,42 +21,12 @@
       description: Factory to create new hosts for ansible
     layer: [ *remote_hosts_layer ]
 
-  - !host
-    id: ansible-master
+  - !variable
+    id: target-password
     annotations:
-      description: Host for running Ansible on remote targets
-
-  - !host
-    id: ansible-custom-target
-    annotations:
-      description: Host for conjurized container which is not conjurized by the role
-
-  - &variables
-    - !variable
-      id: target-password
-      annotations:
-        description: Password needed by the Ansible remote machine
-
-    - !variable
-      id: another-target-password
-      annotations:
-        description: Another password needed by the Ansible remote machine
-
-    - !variable
-      id: master-password
-      annotations:
-        description: Password needed by the Ansible master machine
-
-  - !grant
-    role: *remote_hosts_layer
-    member: !host ansible-custom-target
+      description: Password needed by the Ansible remote machine
 
   - !permit
     role: *remote_hosts_layer
     privileges: [ execute ]
-    resources: [ !variable target-password, !variable another-target-password ]
-
-  - !permit
-    role: !host ansible-master
-    privileges: [ execute ]
-    resource: *variables
+    resources: [ !variable target-password ]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -13,7 +13,6 @@ finish
 # normalises project name by filtering non alphanumeric characters and transforming to lowercase
 declare -x COMPOSE_PROJECT_NAME=$(echo ${BUILD_TAG:-"ansible-role-testing"} | sed -e 's/[^[:alnum:]]//g' | tr '[:upper:]' '[:lower:]')
 
-declare -x CUSTOM_CONJUR_AUTHN_API_KEY=''
 declare -x ANSIBLE_CONJUR_AUTHN_API_KEY=''
 declare -x CLI_CONJUR_AUTHN_API_KEY=''
 declare cli_cid=''
@@ -43,8 +42,6 @@ function setup_conjur {
   # set secret values
   docker exec ${cli_cid} bash -c '
     conjur variable values add ansible/target-password target_secret_password
-    conjur variable values add ansible/another-target-password another_target_secret_password
-    conjur variable values add ansible/master-password ansible_master_secret_password
   '
 }
 
@@ -114,7 +111,6 @@ function main() {
   cli_cid=$(docker-compose ps -q conjur_cli)
   setup_conjur
 
-  CUSTOM_CONJUR_AUTHN_API_KEY=$(api_key_for 'cucumber:host:ansible/ansible-custom-target')
   ANSIBLE_CONJUR_AUTHN_API_KEY=$(api_key_for 'cucumber:host:ansible/ansible-master')
   docker-compose up -d ansible
   ansible_cid=$(docker-compose ps -q ansible)


### PR DESCRIPTION
some hosts and variables in the test policy were used by the module & plugin and aren't used by the role which is what we have in the extracted repo. 

This makes readability hard so I removed them.