### PR TITLE
Add Compatibility for CentOS/RHEL Fix #1

### DIFF
--- a/tasks/identity.yml
+++ b/tasks/identity.yml
@@ -6,7 +6,7 @@
 
 - block:
   - name: Install "ca-certificates"
-    apt:
+    package:
       name: ca-certificates
 
   - name: Place Conjur public SSL certificate


### PR DESCRIPTION
To provide compatibility with CentOS/RHEL and additional package managers other than `apt`, I've changed L9 to use `package` instead and detect the available package manager.