### PR TITLE
Install openssl-perl when EL detected

### DIFF
--- a/tasks/identity.yml
+++ b/tasks/identity.yml
@@ -21,6 +21,12 @@
       dest: /etc/ssl/certs/conjur.crt
       state: link
     register: cert_symlink
+    
+  - name: Install openssl-perl Package
+    yum:
+      name: openssl-perl
+    when:
+      ansible_os_family == 'RedHat'
 
   - name: Rehash certs
     command: 'c_rehash'


### PR DESCRIPTION
`c_rehash` on CentOS/RHEL requires the `openssl-perl` package to be installed via `yum` in order to be able to utilize it.

Added a task to do so when 'RHEL' detected as OS.