### PR TITLE
Updating meta data for Ansible Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,12 @@ galaxy_info:
       versions:
         - trusty
         - xenial
+    - name: CentOS
+      versions:
+        - 7.X
+    - name: RHEL
+      versions:
+        - 7.X
 
   galaxy_tags:
     - machine-identity


### PR DESCRIPTION
Those changes are in addition to the role update to support CentOS/RHEL targets. This way, it will be reflected in the Ansible Galaxy page of the role. 