### PR TITLE
Fix 11 Ansible Galaxy Import Warnings

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,15 +19,12 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
-        - 7.X
-    - name: RHEL
-      versions:
-        - 7.X
+        - 7
 
   galaxy_tags:
-    - machine-identity
+    - identity
     - cyberark
     - conjur
     - security

--- a/tasks/identity.yml
+++ b/tasks/identity.yml
@@ -8,23 +8,25 @@
   - name: Install "ca-certificates"
     package:
       name: ca-certificates
+      retries: 3
 
   - name: Place Conjur public SSL certificate
     copy:
-      dest: "{{conjur_ssl_certificate_path}}"
-      content: "{{conjur_ssl_certificate}}"
+      dest: "{{ conjur_ssl_certificate_path }}"
+      content: "{{ conjur_ssl_certificate }}"
       mode: 0644
 
   - name: Symlink Conjur public SSL certificate into /etc/ssl/certs
     file:
-      src: "{{conjur_ssl_certificate_path}}"
+      src: "{{ conjur_ssl_certificate_path }}"
       dest: /etc/ssl/certs/conjur.crt
       state: link
     register: cert_symlink
-    
+
   - name: Install openssl-perl Package
     yum:
       name: openssl-perl
+      retries: 3
     when:
       ansible_os_family == 'RedHat'
 
@@ -42,14 +44,14 @@
 - block:
   - name: Request identity from Conjur
     uri:
-      url: "{{conjur_appliance_url}}/host_factories/hosts"
+      url: "{{ conjur_appliance_url }}/host_factories/hosts"
       method: POST
-      body: "id={{conjur_host_name}}"
+      body: "id={{ conjur_host_name }}"
       headers:
         Authorization: Token token="{{conjur_host_factory_token}}"
         Content-Type: "application/x-www-form-urlencoded"
       status_code: 201
-      validate_certs: "{{conjur_validate_certs}}"
+      validate_certs: "{{ conjur_validate_certs }}"
     register: host_factory_response
 
   - name: Place identity file /etc/conjur.identity

--- a/tasks/identity.yml
+++ b/tasks/identity.yml
@@ -8,7 +8,7 @@
   - name: Install "ca-certificates"
     package:
       name: ca-certificates
-      retries: 3
+    retries: 3
 
   - name: Place Conjur public SSL certificate
     copy:
@@ -26,7 +26,7 @@
   - name: Install openssl-perl Package
     yum:
       name: openssl-perl
-      retries: 3
+    retries: 3
     when:
       ansible_os_family == 'RedHat'
 

--- a/tasks/summon-conjur.yml
+++ b/tasks/summon-conjur.yml
@@ -7,7 +7,7 @@
 
 - name: Download and unpack Summon-Conjur
   unarchive:
-    src: https://github.com/cyberark/summon-conjur/releases/download/v{{summon_conjur.version}}/summon-conjur-{{summon_conjur.os}}.tar.gz
+    src: https://github.com/cyberark/summon-conjur/releases/download/v{{ summon_conjur.version }}/summon-conjur-{{ summon_conjur.os }}.tar.gz
     dest: /usr/local/lib/summon
     remote_src: yes
     creates: /usr/local/lib/summon/summon-conjur

--- a/tasks/summon.yml
+++ b/tasks/summon.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download and unpack Summon
   unarchive:
-    src: https://github.com/cyberark/summon/releases/download/v{{summon.version}}/summon-{{summon.os}}.tar.gz
+    src: https://github.com/cyberark/summon/releases/download/v{{ summon.version }}/summon-{{ summon.os }}.tar.gz
     dest: /usr/local/bin
     remote_src: yes
     creates: /usr/local/bin/summon


### PR DESCRIPTION
Cleared most, but not all, ansible-lint warnings.  The only one that should persist is a 120-char max limit breach for a URL in [](tasks/summon-conjur.yml) that I can't do anything about.

The `invalid platform` errors were also fixed.  Combined RHEL and CentOS to EL and changed the versions to 7.

We will need to tag a release for v0.3.0 after merging this with master and refresh the import on Ansible Galaxy for changes to be reflected.