### PR TITLE
Fix #13 - ansible lint warning cleanup

### DIFF
--- a/tasks/identity.yml
+++ b/tasks/identity.yml
@@ -9,7 +9,7 @@
     package:
       name: ca-certificates
     register: ca-cert_install
-    until: ca-cert_install is success
+    until: ca-cert_install|succeeded
     retries: 10
     delay: 2
 
@@ -32,7 +32,7 @@
     when:
       ansible_os_family == 'RedHat'
     register: openssl_install
-    until: openssl_install is success
+    until: openssl_install|succeeded
     retries: 10
     delay: 2
 

--- a/tasks/identity.yml
+++ b/tasks/identity.yml
@@ -8,7 +8,10 @@
   - name: Install "ca-certificates"
     package:
       name: ca-certificates
-    retries: 3
+    register: ca-cert_install
+    until: ca-cert_install is success
+    retries: 10
+    delay: 2
 
   - name: Place Conjur public SSL certificate
     copy:
@@ -26,9 +29,12 @@
   - name: Install openssl-perl Package
     yum:
       name: openssl-perl
-    retries: 3
     when:
       ansible_os_family == 'RedHat'
+    register: openssl_install
+    until: openssl_install is success
+    retries: 10
+    delay: 2
 
   - name: Rehash certs
     command: 'c_rehash'
@@ -48,7 +54,7 @@
       method: POST
       body: "id={{ conjur_host_name }}"
       headers:
-        Authorization: Token token="{{conjur_host_factory_token}}"
+        Authorization: Token token="{{ conjur_host_factory_token }}"
         Content-Type: "application/x-www-form-urlencoded"
       status_code: 201
       validate_certs: "{{ conjur_validate_certs }}"

--- a/tasks/identity.yml
+++ b/tasks/identity.yml
@@ -8,8 +8,6 @@
   - name: Install "ca-certificates"
     package:
       name: ca-certificates
-    register: ca-cert_install
-    until: ca-cert_install|succeeded
     retries: 10
     delay: 2
 
@@ -31,8 +29,6 @@
       name: openssl-perl
     when:
       ansible_os_family == 'RedHat'
-    register: openssl_install
-    until: openssl_install|succeeded
     retries: 10
     delay: 2
 

--- a/tasks/identity_check.yml
+++ b/tasks/identity_check.yml
@@ -6,10 +6,10 @@
 
 - name: Set fact "conjurized"
   set_fact:
-    conjurized: "{{identity_file.stat.exists|bool}}"
+    conjurized: "{{ identity_file.stat.exists|bool }}"
 
 - name: Ensure all required variables are set
-  fail: msg="Variable '{{item}}' is not set!"
+  fail: msg="Variable '{{ item }}' is not set!"
   when: item is undefined
   with_items:
     - "{{ conjur_account }}"
@@ -18,11 +18,11 @@
 
 - name: Set fact "ssl_configuration"
   set_fact:
-    ssl_configuration: "{{'https' in conjur_appliance_url}}"
+    ssl_configuration: "{{ 'https' in conjur_appliance_url }}"
 
 - block:
   - name: Ensure all required ssl variables are set
-    fail: msg="Variable '{{item}}' is not set!"
+    fail: msg="Variable '{{ item }}' is not set!"
     when: item is undefined
     with_items:
       - "{{ conjur_ssl_certificate }}"
@@ -42,7 +42,7 @@
 
 - block:
   - name: Ensure "conjur_host_factory_token" is set (if node is not already conjurized)
-    fail: msg="Variable '{{item}}' is not set!"
+    fail: msg="Variable '{{ item }}' is not set!"
     when: item is undefined
     with_items:
       - "{{ conjur_host_factory_token }}"


### PR DESCRIPTION
Fixed all pending ansible-lint warnings from Ansible Galaxy import with the exception of the URL breaching 120 chars max limit in [](tasks/summon-conjur.yml).