### PR TITLE
Merge pull request #20 from cyberark/conjurinc-ops-484

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,12 +1,14 @@
-FROM ansible/ansible:ubuntu1604
-
-RUN pip install testinfra ansible pytest==2.9.2 && mkdir -p /conjurinc/
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y \
     apt-transport-https \
     ca-certificates \
     curl \
-    software-properties-common
+    software-properties-common \
+    python-pip
+
+RUN pip install -U pip
+RUN pip install pytest==2.9.2 testinfra ansible && mkdir -p /conjurinc/
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN add-apt-repository \
@@ -19,3 +21,5 @@ RUN apt-add-repository -y ppa:brightbox/ruby-ng && apt-get update && apt-get ins
 RUN gem install conjur-cli
 
 WORKDIR /conjurinc/
+
+CMD ["/bin/sleep", "1d"]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -94,7 +94,7 @@ function generate_inventory {
   # uses .j2 template to generate inventory prepended with COMPOSE_PROJECT_NAME
   docker exec $(docker-compose ps -q ansible) bash -c '
     cd tests
-    ansible-playbook -i -, inventory-playbook.yml
+    ansible-playbook inventory-playbook.yml
   '
 }
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -87,12 +87,12 @@ function wait_for_server {
 }
 
 function fetch_ssl_cert {
-  docker exec $(docker-compose ps -q conjur-proxy-nginx) cat cert.crt > conjur.pem
+  (docker-compose exec -T conjur-proxy-nginx cat cert.crt) > conjur.pem
 }
 
 function generate_inventory {
   # uses .j2 template to generate inventory prepended with COMPOSE_PROJECT_NAME
-  docker exec $(docker-compose ps -q ansible) bash -c '
+  docker-compose exec -T ansible bash -c '
     cd tests
     ansible-playbook inventory-playbook.yml
   '


### PR DESCRIPTION
The test script specifies the inventory as `-,` which isn't valid.
This commit removes the inventory specification as ansible will
implicit create an inventory that only contains localhost and
that is sufficient for the playbook being run.

Related: conjurinc/ops#484