### PR TITLE
Add Retries to host factory request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Updated reference to Conjur CLI container
 - Updated base image to Ubuntu 18.04
+- [Added retries](https://github.com/cyberark/ansible-conjur-host-identity/pull/32) to tasks/identity/Request identity from Conjur.
+  This will increase the reliability of host factory requests without introducing any extra delay if the first request succeeds.
 
 ## [0.3.1] - 2019-02-27
 ### Fixed

--- a/tasks/identity.yml
+++ b/tasks/identity.yml
@@ -55,6 +55,9 @@
       status_code: 201
       validate_certs: "{{ conjur_validate_certs }}"
     register: host_factory_response
+    retries: 3
+    delay: 10
+    until: host_factory_response.status == 201
 
   - name: Place identity file /etc/conjur.identity
     template:


### PR DESCRIPTION
Retries may be necessary if the conjur instance is busy, or if a
load balancer is updating.

Related: conjurinc/ops#596