### PR TITLE
Fix broken master build - ansible install failure

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,10 +5,9 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     software-properties-common \
-    python-pip
+    python3-pip
 
-RUN pip install -U pip
-RUN pip install pytest==2.9.2 testinfra ansible && mkdir -p /conjurinc/
+RUN pip3 install pytest testinfra ansible && mkdir -p /conjurinc/
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN add-apt-repository \

--- a/tests/test_app_centos/Dockerfile
+++ b/tests/test_app_centos/Dockerfile
@@ -1,4 +1,4 @@
 FROM centos:7
 
 # Install Python so Ansible can run against node
-RUN yum update -y && yum install -y python
+RUN yum update -y && yum install -y python3

--- a/tests/test_app_ubuntu/Dockerfile
+++ b/tests/test_app_ubuntu/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:16.04
 
 # Install Python so Ansible can run against node
-RUN apt-get update -y && apt-get install -y python-minimal
+RUN apt-get update -y && apt-get install -y python3-minimal


### PR DESCRIPTION
### What does this PR do?
Previously, the master build was failing due to an issue with an older version of `pip` being
used to install ansible.

We removed references to `python` and `pip` in favor of `python3` and `pip3` to 
ensure future compatibility, and fix the installation issue.

### What ticket does this PR close?
Connected to #39 
Connected to #41 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation