### PR TITLE
Fix tests

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -40,8 +40,6 @@ services:
       CONJUR_AUTHN_API_KEY: ${CLI_CONJUR_AUTHN_API_KEY}
     volumes:
       - ./policy:/policy
-    links:
-      - conjur
 
   test_app_ubuntu:
     build: ./test_app_ubuntu

--- a/tests/inventory.j2
+++ b/tests/inventory.j2
@@ -1,6 +1,6 @@
 [testapp]
-{{ lookup('env','COMPOSE_PROJECT_NAME') }}_test_app_ubuntu_[1:2] ansible_connection=docker
-{{ lookup('env','COMPOSE_PROJECT_NAME') }}_test_app_centos_[1:2] ansible_connection=docker
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}-test_app_ubuntu-[1:2] ansible_connection=docker
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}-test_app_centos-[1:2] ansible_connection=docker
 
 [ansible]
-{{ lookup('env','COMPOSE_PROJECT_NAME') }}_ansible_1 ansible_connection=docker
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}-ansible-1 ansible_connection=docker


### PR DESCRIPTION
Fix docker-compose test environment. A recent change in Jenkins is causing linked containers/dependencies to be rebuilt after they have already been configured